### PR TITLE
Improve Inline Markdown plugins

### DIFF
--- a/collapsible-state-field.js
+++ b/collapsible-state-field.js
@@ -1,0 +1,60 @@
+import { StateField } from '@codemirror/state';
+import { Decoration, EditorView } from "@codemirror/view";
+import { ReplacementWidget } from "./replacement-widget";
+
+// Creates a new StateField with internal "hiddenDecorations" RangeSet state.
+// Accepts a "decorate" function that creates the decorations RangeSet.
+//
+// CollapsibleStateField probably isn't the best name. The decorations themselves
+// are "collapsible", not the StateField itself.
+export function newCollapsibleStateField(decorate) {
+  let hiddenDecorations;
+
+  return StateField.define({
+    create(state) {
+      return decorate(state);
+    },
+    update(value, transaction) {
+      let hideDecorations = false;
+
+      // Get the decorations that may or may not be shown based on the current doc.
+      const decorations = transaction.docChanged ? decorate(transaction.state) : value.map(transaction.changes);
+      const selection = transaction.state.selection.main;
+
+      // All decorations should be hidden if the cursor is inside the
+      // ReplacementWidget decoration.
+      decorations.between(selection.from, selection.to, (_from, _to, value) => {
+        if (value.widget instanceof ReplacementWidget) {
+          hideDecorations = true;
+        }
+      });
+
+      // Even if there are currently hidden decorations, still set the hidden
+      // state to true if the cursor is inside the ReplacementWidget decoration.
+      if (hiddenDecorations) {
+        hiddenDecorations.between(selection.from, selection.to, (_from, _to, value) => {
+          if (value.widget instanceof ReplacementWidget) {
+            hideDecorations = true;
+          }
+        });
+      }
+
+      if (hideDecorations) {
+        // If the decorations should be hidden and there are decorations currently being shown,
+        // store them in the "hiddenDecorations" state and return 0 decorations
+        if (decorations.length) hiddenDecorations = decorations;
+        return Decoration.none;
+      } else if (hiddenDecorations) {
+        // If the decorations should NOT be hidden, but there are
+        // some currently being stored, return those.
+        return hiddenDecorations;
+      }
+
+      // If the decorations should NOT be hidden, and there are none stored in state, just return them.
+      return decorations;
+    },
+    provide(field) {
+      return EditorView.decorations.from(field);
+    }
+  });
+}

--- a/image-widget.js
+++ b/image-widget.js
@@ -1,0 +1,42 @@
+import { WidgetType } from "@codemirror/view";
+
+export class ImageWidget extends WidgetType {
+  constructor({ url }) {
+    super();
+    this.url = url;
+  }
+
+  eq(imageWidget) {
+    return imageWidget.url === this.url;
+  }
+
+  toDOM() {
+    const container = document.createElement("div");
+    const figure = container.appendChild(document.createElement("figure"));
+    const image = figure.appendChild(document.createElement("img"));
+
+    container.setAttribute("aria-hidden", "true");
+    container.className = "cm-image-container";
+    figure.className = "cm-image-figure";
+    image.className = "cm-image-img";
+    image.src = this.url;
+
+    container.style.backgroundColor = "var(--hybrid-mde-images-bg-color, rgba(0, 0, 0, 0.3))";
+    container.style.display = "flex";
+    container.style.alignItems = "center";
+    container.style.justifyContent = "center";
+    container.style.padding = "1rem";
+    container.style.marginBottom = "0.5rem";
+    container.style.marginTop = "0.5rem";
+    container.style.maxWidth = "100%";
+
+    figure.style.margin = "0";
+
+    image.style.display = "block";
+    image.style.maxHeight = "var(--hybrid-mde-images-max-height, 20rem)";
+    image.style.maxWidth = "100%";
+    image.style.width = "100%";
+
+    return container;
+  }
+}

--- a/inline-images.js
+++ b/inline-images.js
@@ -1,52 +1,10 @@
 import { syntaxTree } from "@codemirror/language";
-import { RangeSet, StateField } from '@codemirror/state';
-import {
-  Decoration,
-  EditorView,
-  WidgetType
-} from "@codemirror/view";
+import { RangeSet } from '@codemirror/state';
+import { Decoration } from "@codemirror/view";
+
+import { newCollapsibleStateField } from "./collapsible-state-field";
+import { ImageWidget } from "./image-widget";
 import { ReplacementWidget } from "./replacement-widget";
-
-class ImageWidget extends WidgetType {
-  constructor({ url }) {
-    super();
-    this.url = url;
-  }
-
-  eq(imageWidget) {
-    return imageWidget.url === this.url;
-  }
-
-  toDOM() {
-    const container = document.createElement("div");
-    const figure = container.appendChild(document.createElement("figure"));
-    const image = figure.appendChild(document.createElement("img"));
-
-    container.setAttribute("aria-hidden", "true");
-    container.className = "cm-image-container";
-    figure.className = "cm-image-figure";
-    image.className = "cm-image-img";
-    image.src = this.url;
-
-    container.style.backgroundColor = "var(--hybrid-mde-images-bg-color, rgba(0, 0, 0, 0.3))";
-    container.style.display = "flex";
-    container.style.alignItems = "center";
-    container.style.justifyContent = "center";
-    container.style.padding = "1rem";
-    container.style.marginBottom = "0.5rem";
-    container.style.marginTop = "0.5rem";
-    container.style.maxWidth = "100%";
-
-    figure.style.margin = "0";
-
-    image.style.display = "block";
-    image.style.maxHeight = "var(--hybrid-mde-images-max-height, 20rem)";
-    image.style.maxWidth = "100%";
-    image.style.width = "100%";
-
-    return container;
-  }
-}
 
 export const inlineImages = () => {
   const imageRegex = /!\[.*\]\((?<url>.*)\)/;
@@ -64,7 +22,7 @@ export const inlineImages = () => {
   });
 
   const decorate = state => {
-    const widgets = [];
+    const decorations = [];
 
     syntaxTree(state).iterate({
       enter: ({ type, from, to }) => {
@@ -72,40 +30,19 @@ export const inlineImages = () => {
           const result = imageRegex.exec(state.doc.sliceString(from, to));
 
           if (result && result.groups && result.groups.url) {
-            widgets.push(imageDecoration({ url: result.groups.url }).range(state.doc.lineAt(from).from));
-
-            // Comment out this next line to remove the link emoji replacement.
-            widgets.push(replacementDecoration({ url: result.groups.url }).range(from, to));
+            decorations.push(imageDecoration({ url: result.groups.url }).range(state.doc.lineAt(from).from));
+            decorations.push(replacementDecoration({ url: result.groups.url }).range(from, to));
           }
         }
       }
     });
 
-    return widgets.length > 0 ? RangeSet.of(widgets) : Decoration.none;
+    return decorations.length > 0 ? RangeSet.of(decorations) : Decoration.none;
   };
 
-  const imagesField = StateField.define({
-    create(state) {
-      return decorate(state);
-    },
-    update(images, transaction) {
-      if (transaction.docChanged) {
-        return decorate(transaction.state);
-      }
-
-      // I'm trying to write something here to determine where the cursor is
-      // at this point to dynamically show/hide widgets.
-
-      return images.map(transaction.changes);
-    },
-    provide(field) {
-      // Maybe using EditorView.decorations.computeN would be helpful here
-      // but so far I haven't been able tog get it to work.
-      return EditorView.decorations.from(field);
-    }
-  });
+  const stateField = newCollapsibleStateField(decorate);
 
   return [
-    imagesField,
+    stateField,
   ]
 };

--- a/inline-links.js
+++ b/inline-links.js
@@ -1,9 +1,7 @@
 import { syntaxTree } from "@codemirror/language";
-import { RangeSet, StateField } from '@codemirror/state';
-import {
-  Decoration,
-  EditorView
-} from "@codemirror/view";
+import { RangeSet } from '@codemirror/state';
+import { Decoration } from "@codemirror/view";
+import { newCollapsibleStateField } from "./collapsible-state-field";
 import { ReplacementWidget } from "./replacement-widget";
 
 export const inlineLinks = () => {
@@ -33,23 +31,9 @@ export const inlineLinks = () => {
     return widgets.length > 0 ? RangeSet.of(widgets) : Decoration.none;
   };
 
-  const linkField = StateField.define({
-    create(state) {
-      return decorate(state);
-    },
-    update(links, transaction) {
-      if (transaction.docChanged) {
-        return decorate(transaction.state);
-      }
-
-      return links.map(transaction.changes);
-    },
-    provide(field) {
-      return EditorView.decorations.from(field);
-    }
-  });
+  const stateField = newCollapsibleStateField(decorate);
 
   return [
-    linkField,
+    stateField,
   ]
 };


### PR DESCRIPTION
This PR does the following:

- Improves the plugins so they work about as expected (renders plain links as "collapsed" emoji and image links as collapsed emoji with the image rendered above it)
- Separates the different components: CollapsibleStateField, ImageWidget, ReplacementWidget, and the two plugins InlineImages and InlineLinks
- Renames a few variables for clarity

I added some comments to the CollapsibleStateField component to explain how it works.